### PR TITLE
Add install.sh script, which is run once codespace is created

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/ryboe/alpinecodespace:latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "codespace-dotfiles",
+    "build": {
+        "dockerfile": "Dockerfile",
+    },
+    "settings": {
+        "[dockerfile]": {
+            "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+        },
+        "editor.formatOnSave": true,
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true,
+        "files.trimTrailingWhitespace": true,
+    },
+    "extensions": [
+        "davidanson.vscode-markdownlint",
+        "foxundermoon.shell-format",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+    ],
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.devcontainer/
-.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "davidanson.vscode-markdownlint",
+        "foxundermoon.shell-format",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "[dockerfile]": {
+        "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+    },
+    "editor.formatOnSave": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Codespace Dotfiles
 
-A bunch of Linux config files specifically for use with
-[`ryboe/alpinecodespace`](https://github.com/ryboe/alpinecodespace).
+A bunch of Linux config files specifically for use with and Alpine-based
+Codespace image, like [`ryboe/alpinecodespace`](https://github.com/ryboe/alpinecodespace).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+install_tools() {
+    # fzf depends on perl :(
+    sudo apk add --update bat exa fd file fzf neovim perl ripgrep shfmt
+
+    sudo wget --quiet --timeout=30 --output-document=/usr/local/bin/gitprompt https://github.com/ryboe/gitprompt/releases/latest/download/gitprompt-x86_64-unknown-linux-musl
+    sudo chmod +x /usr/local/bin/gitprompt
+
+    # Install fzf shell integration functions to /usr/share/fzf.
+    sudo wget --quiet --timeout=30 --output-document=/usr/share/fzf/completion.zsh https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh
+    sudo wget --quiet --timeout=30 --output-document=/usr/share/fzf/key-bindings.zsh https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh
+}
+
+create_symlinks() {
+    script_dir=${0:a:h}
+
+    rm -rf ~/.bashrc ~/.config ~/.oh-my-zsh ~/.zshrc
+    mkdir -p ~/.config/git
+    ln -s "$script_dir/.config/git/config" $HOME/.config/git/config
+    ln -s "$script_dir/.config/git/ignore" $HOME/.config/git/ignore
+    ln -s "$script_dir/.zshrc" $HOME/.zshrc
+}
+
+main() {
+    install_tools
+
+    create_symlinks
+}
+
+main


### PR DESCRIPTION
`install.sh` is run once when the container is first created. It will install and configure a bunch of packages that are specific to my workflow. Then it will symlink config files into the `vscode` user's home directory.

Using `install.sh` avoids everything in this repo being copied into the `vscode` user's home directory. `install.sh` explicitly controls what gets linked. We don't have to omit the `.vscode/` and `.devcontainer/` config files anymore, because they won't be copied into the codespace.