### PR TITLE
Remove perl dependency

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "codespace-dotfiles",
     "build": {
-        "dockerfile": "Dockerfile",
+        "dockerfile": "Dockerfile"
     },
     "settings": {
         "[dockerfile]": {
@@ -10,12 +10,12 @@
         "editor.formatOnSave": true,
         "files.insertFinalNewline": true,
         "files.trimFinalNewlines": true,
-        "files.trimTrailingWhitespace": true,
+        "files.trimTrailingWhitespace": true
     },
     "extensions": [
         "davidanson.vscode-markdownlint",
         "foxundermoon.shell-format",
         "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml",
-    ],
+        "redhat.vscode-yaml"
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
         "davidanson.vscode-markdownlint",
         "foxundermoon.shell-format",
         "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml",
+        "redhat.vscode-yaml"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "editor.formatOnSave": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 install_tools() {
-    # fzf depends on perl :(
-    sudo apk add --update bat exa fd file fzf neovim perl ripgrep shfmt
+    sudo apk add --update bat exa fd file fzf neovim ripgrep shfmt
 
     sudo wget --quiet --timeout=30 --output-document=/usr/local/bin/gitprompt https://github.com/ryboe/gitprompt/releases/latest/download/gitprompt-x86_64-unknown-linux-musl
     sudo chmod +x /usr/local/bin/gitprompt


### PR DESCRIPTION
In Alpine 3.16, there's an updated version of `fzf` that no longer depends on `perl`. So we don't have to install it in `install.sh` anymore.
