### PR TITLE
Workaround for zsh completions installation error on Debian

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
     "name": "codespace-dotfiles",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "image": "ghcr.io/ryboe/alpinecodespace:latest",
     "settings": {
         "[dockerfile]": {
             "editor.defaultFormatter": "ms-azuretools.vscode-docker"

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,10 @@ install_tools_alpine() {
 }
 
 install_tools_debian() {
+    # apt will try to install completions to this dir, but it won't create the
+    # directory for some reason.
+    mkdir -p /usr/share/fzf
+
     sudo apt update
     # shfmt is not available on apt yet. The shfmt package is named
     # golang-mvdan-sh, but it's only in testing. See this URL for status
@@ -41,7 +45,8 @@ install_tools() {
 }
 
 create_symlinks() {
-    rm -rf ~/.bashrc ~/.config ~/.oh-my-zsh ~/.zshrc
+    # Delete any existing configs.
+    rm -rf ~/.bash_logout ~/.bashrc ~/.config ~/.oh-my-zsh ~/.profile ~/.zshrc
     mkdir -p ~/.config/git
 
     script_dir=${0:a:h}


### PR DESCRIPTION
For some reason, apt will try to install fzf completions without creating the `/usr/share/fzf` directory first. Workaround this by creating it manually.

Also simplify the `devcontainer.json` config by removing the Dockerfile and just pulling `ghcr.io/ryboe/alpinecodespace:latest`.

Finally, remove a few junk default configs from the `pythoncodespace` image if they exist.
