### PR TITLE
feat: Update devcontainer.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,0 @@
-# syntax=docker/dockerfile:1
-FROM ghcr.io/ryboe/alpinecodespace:latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,23 @@
 {
     "name": "codespace-dotfiles",
     "image": "ghcr.io/ryboe/alpinecodespace:latest",
-    "settings": {
-        "[dockerfile]": {
-            "editor.defaultFormatter": "ms-azuretools.vscode-docker"
-        },
-        "editor.formatOnSave": true,
-        "files.insertFinalNewline": true,
-        "files.trimFinalNewlines": true,
-        "files.trimTrailingWhitespace": true
-    },
-    "extensions": [
-        "davidanson.vscode-markdownlint",
-        "foxundermoon.shell-format",
-        "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml"
-    ]
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "[dockerfile]": {
+                    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+                },
+                "editor.formatOnSave": true,
+                "files.insertFinalNewline": true,
+                "files.trimFinalNewlines": true,
+                "files.trimTrailingWhitespace": true
+            },
+            "extensions": [
+                "davidanson.vscode-markdownlint",
+                "foxundermoon.shell-format",
+                "ms-azuretools.vscode-docker",
+                "redhat.vscode-yaml"
+            ]
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Codespace Dotfiles
 
-A bunch of Linux config files specifically for use with and Alpine-based
-Codespace image, like [`ryboe/alpinecodespace`](https://github.com/ryboe/alpinecodespace).
+A bunch of Linux config files for use with and Alpine-based or Debian-based
+codespaces, like [`ryboe/alpinecodespace`](https://github.com/ryboe/alpinecodespace).


### PR DESCRIPTION
The new devcontainer schema moves vscode-specific settings inside the customizations > vscode key.

Also update the README to reflect that these dotfiles work on Debian-based distros, not just Alpine.
